### PR TITLE
Queues state changes on the main thread.

### DIFF
--- a/Sources/StateMachine.swift
+++ b/Sources/StateMachine.swift
@@ -2,38 +2,40 @@ import Foundation
 
 
 public class StateMachine<T: StateType> {
-  /// This private stored property serves as the backing for the public computed `state` property. This lets us use `state` as a gatekeeper that filters out invalid transitions. It also gives us a (private) mechanisim to set state without triggering handlers.
-  private var _state: T
+  /// The current state of the state machine. Read-only.
+  public private(set) var state: T
 
-  
-  /// The state of the state machine. To transition states, set this property.
-  /// Note that attempts to set this property to an invalid state (as determined by `StateType.shouldTransitionFrom(_,to:)`) are silently ignored.
-  public var state: T {
-    get {
-      return _state
-    }
-    set { //Can't be an observer because we need the option to CONDITIONALLY set state
-      delegateTransitionTo(newValue)
+  /// Use this method to transition states. It first take the given `state` and determine its validity via `StateType.shouldTransitionFrom(_,to:)`. If it is, it transitions the machine to it, calling `transformationHandler` once complete. If not, the given `state` is silently ignored.
+  /// * parameter state: The state to transition to.
+  /// * Note: This method queues the state transition to happen on the next pass of the run loop. Thus, it's safe to call `queueState(_)` from `transitionHandler` without concern for the stack. However, this also means that even valid calls to `queueState(_)` will not be reflected immediately in the state machine:
+  /// ````
+  /// let machine = StateMachine(initialState: State.Ready)
+  /// machine.queueState(State.Fetch)
+  /// machine.state //> State.Ready
+  /// ````
+  public func queueState(state: T) {
+    NSOperationQueue.mainQueue().addOperationWithBlock { () -> Void in
+      self.delegateTransitionTo(state)
     }
   }
   
 
   /// Closure that gets called whenever `StateMachine` successfully transitions from one state to another.
-  /// * Warning: There's a high likelihood a) the class using a given state machine will hold a strong reference to it and, b) the closure the class assigns to this property of the state machine will reference `self`. This will create a retain cycle if `self` isn't declared as `unowned` in a capture list. See [String Reference Cycles for Closures](https://developer.apple.com/library/prerelease/ios/documentation/Swift/Conceptual/Swift_Programming_Language/AutomaticReferenceCounting.html#//apple_ref/doc/uid/TP40014097-CH20-ID56).
+  /// * Warning: There's a high likelihood a) the class using a given state machine will hold a strong reference to it and, b) the closure the class assigns to this property will reference `self`. This will create a retain cycle if `self` isn't declared as `unowned` in a capture list. See [String Reference Cycles for Closures](https://developer.apple.com/library/prerelease/ios/documentation/Swift/Conceptual/Swift_Programming_Language/AutomaticReferenceCounting.html#//apple_ref/doc/uid/TP40014097-CH20-ID56).
   public var transitionHandler: (T,T)->Void = { _,_ in }
 
 
   /// Initializes the state machine with the given initial state.
-  /// This could very easily also take a(n optional) `transitionHandler`, saving us a common assignment that will almost always take place directly after instantiation. But a common confusion I run in to using `StateMachine` is an inability to remember whether `transitionHandler` is called when setting the initial state or not. Keeping the assignment seperate makes the answer to this question obvious.
+  /// This could very easily also take a(n optional) `transitionHandler`, saving us a common assignment that will almost always take place directly after instantiation. But I'm always forgetting whether `transitionHandler` is called when setting the initial state or not. Keeping the assignment seperate makes the answer to this question obvious.
   public init(initialState: T) {
-    _state = initialState //set the internal value so we don't need a special rule in «shouldTranistionFrom(_,to:)». Also avoids calling «transitionHandler».
+    state = initialState //set the internal value so we don't need a special rule in «shouldTranistionFrom(_,to:)». Also avoids calling «transitionHandler».
   }
   
   
   private func delegateTransitionTo(to: T) {
     if state.shouldTransitionFrom(state, to:to){
       let from = state //If «T» is a mutable ref type, this will do Bad Things.
-      _state = to //uses internal value to prevent looping.
+      state = to
       transitionHandler(from, to)
     }
   }

--- a/Sources/StateType.swift
+++ b/Sources/StateType.swift
@@ -1,6 +1,6 @@
 import Foundation
 
 
-public protocol StateType{
-  func shouldTransitionFrom(from:Self, to:Self)->Bool
+public protocol StateType {
+  func shouldTransitionFrom(from: Self, to: Self) -> Bool
 }

--- a/Support/Gauntlet.xcodeproj/xcshareddata/xcschemes/FiniteGauntlet.xcscheme
+++ b/Support/Gauntlet.xcodeproj/xcshareddata/xcschemes/FiniteGauntlet.xcscheme
@@ -29,7 +29,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "73E4FD151AFD4E040058C1AF"
-               BuildableName = "Gauntlet.xctest"
+               BuildableName = "GauntletTests.xctest"
                BlueprintName = "GauntletTests"
                ReferencedContainer = "container:Gauntlet.xcodeproj">
             </BuildableReference>
@@ -47,7 +47,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "73E4FD151AFD4E040058C1AF"
-               BuildableName = "Gauntlet.xctest"
+               BuildableName = "GauntletTests.xctest"
                BlueprintName = "GauntletTests"
                ReferencedContainer = "container:Gauntlet.xcodeproj">
             </BuildableReference>

--- a/Support/Info.plist
+++ b/Support/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.4</string>
+	<string>0.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Tests/CaptureSelfTests.swift
+++ b/Tests/CaptureSelfTests.swift
@@ -79,7 +79,7 @@ class CaptureSelfTests: XCTestCase {
          }
        }
    
-   But for now that leaks.
+   But for now it leaks.
    */
   func testDirectAssignment() {
     var subject = Optional(Foo(ref: ref))

--- a/Tests/TransitionTests.swift
+++ b/Tests/TransitionTests.swift
@@ -2,68 +2,181 @@ import Foundation
 import XCTest
 import Gauntlet
 
+func ==(lhs: TransitionTests.State, rhs: TransitionTests.State) -> Bool {
+  switch (lhs, rhs){
+  case (.Ready, .Ready), (.Working, .Working), (.Success, .Success), (.Failure, .Failure):
+    return true
+  default:
+    return false
+  }
+}
+
 
 class TransitionTests : XCTestCase{
-  enum State: StateType {
+  enum State: StateType, Equatable {
     case Ready, Working, Success(String), Failure(NSError)
     func shouldTransitionFrom(from: State, to: State) -> Bool {
       switch (from, to) {
       case
       (.Ready, .Ready),
-      (.Ready, .Working):
+      (.Ready, .Working),
+      (.Working, .Ready):
         return true
       default:
         return false
       }
     }
   }
-
-
   var machine = StateMachine(initialState: State.Ready)
 
   
-  func testValidTransition(){
+  func testTransitionDelay(){
+    let expectWorking = expectationWithDescription("Completed Transition")
     machine.transitionHandler = { from, to in
       if case (.Ready, .Working) = (from, to) {
-        XCTAssert(true)
-      } else {
-        XCTFail("Transition to valid state didn't trigger handler.")
+        expectWorking.fulfill()
       }
     }
-    machine.state = .Working
+    machine.queueState(.Working)
+    XCTAssertEqual(machine.state, State.Ready, "The transistion doesn't happen until the next run loop")
+    waitForExpectationsWithTimeout(2) { error in
+      XCTAssertEqual(self.machine.state, State.Working)
+    }
+  }
+  
+  
+  func testValidTransition(){
+    let expectWorking = expectationWithDescription("Completed Transition")
+
+    machine.transitionHandler = { from, to in
+      if case (.Ready, .Working) = (from, to) {
+        expectWorking.fulfill()
+      }
+    }
+    machine.queueState(.Working)
+    
+    waitForExpectationsWithTimeout(2) { _ in
+      XCTAssertEqual(self.machine.state, State.Working)
+    }
+  }
+  
+  
+  func testMultipleTransitions(){
+    let expectWorking = expectationWithDescription("Completed Working")
+    let expectReady = expectationWithDescription("Completed Ready")
+
+    machine.transitionHandler = { _, to in
+      switch to {
+      case .Working:
+        expectWorking.fulfill()
+      case .Ready:
+        expectReady.fulfill()
+      default:
+        XCTFail()
+      }
+    }
+    machine.queueState(.Working)
+    machine.queueState(.Ready)
+    
+    waitForExpectationsWithTimeout(2) { _ in
+      XCTAssertEqual(self.machine.state, State.Ready)
+    }
+  }
+  
+  
+  /// `testInvalidTransition` relies on the state-changing operation completing before the expectation is fulfilled (which it always should, because the main queue is essentially FIFO). This tests that that's true.
+  func testTimingForInvalidTransition() {
+    var didTransition = false
+    let expectQueued = expectationWithDescription("Queued Expectation")
+    
+    machine.transitionHandler = { from, to in
+      didTransition = true
+    }
+    //This will put the state-changing operation on the main queue.
+    machine.queueState(.Working)
+    //This will queue up another operation -- after the state-changing one.
+    NSOperationQueue.mainQueue().addOperationWithBlock { expectQueued.fulfill() }
+    
+    waitForExpectationsWithTimeout(2) { _ in
+      XCTAssert(didTransition, "Our expectation should fulfill *after* the transition completes.")
+    }
   }
   
   
   func testInvalidTransition(){
+    let expectQueued = expectationWithDescription("Queued Expectation")
+
     machine.transitionHandler = { from, to in
-      if case (.Ready, .Success) = (from, to) {
-        XCTFail("Transition is invalid")
-      }
+      XCTFail("Handler for invalid transition should not have been called.")
     }
-    machine.state = .Success("foo")
+    machine.queueState(.Success("foo"))
+    NSOperationQueue.mainQueue().addOperationWithBlock { expectQueued.fulfill() }
+    
+    waitForExpectationsWithTimeout(2) { _ in
+      XCTAssertEqual(self.machine.state, State.Ready)
+    }
   }
 
   
   func testValidDoubleTransition(){
+    let expectDoubleReady = expectationWithDescription("Transition Complete")
+
     machine.transitionHandler = { from, to in
       if case (.Ready, .Ready) = (from, to) {
-        XCTAssert(true)
-      } else {
-        XCTFail("Transition to same state didn't trigger handler.")
+        expectDoubleReady.fulfill()
       }
     }
-    machine.state = .Ready
+    machine.queueState(.Ready)
+
+    waitForExpectationsWithTimeout(2) { _ in
+      XCTAssertEqual(self.machine.state, State.Ready)
+    }
   }
   
   
-  func testInvaludDoubleTransition(){
+  func testInvalidDoubleTransition(){
+    let expectWorking = expectationWithDescription("Transition Complete")
+    let expectQueued = expectationWithDescription("Queued Expectation")
+    
     machine.transitionHandler = { from, to in
-      if case (.Working, .Working) = (from, to){
+      switch (from, to) {
+      case (.Ready, .Working):
+        expectWorking.fulfill()
+      default:
         XCTFail("Transition is invalid.")
       }
     }
-    machine.state = .Working
-    machine.state = .Working
+    machine.queueState(.Working)
+    machine.queueState(.Working)
+    NSOperationQueue.mainQueue().addOperationWithBlock { expectQueued.fulfill() }
+    
+    waitForExpectationsWithTimeout(2) { _ in
+      XCTAssertEqual(self.machine.state, State.Working)
+    }
+  }
+  
+  
+  func testNestedTransitions(){
+    let expectReady = expectationWithDescription("Transition Complete")
+    let expectWorking = expectationWithDescription("Transition Complete")
+    var inWorking = false
+    
+    machine.transitionHandler = { _, to in
+      switch to {
+      case .Ready:
+        XCTAssertFalse(inWorking, "no other handler should be on the stack")
+        expectReady.fulfill()
+      case .Working:
+        inWorking = true
+        defer { inWorking = false }
+        expectWorking.fulfill()
+        self.machine.queueState(.Ready)
+      default:
+        XCTFail()
+      }
+    }
+    machine.queueState(.Working)
+    
+    waitForExpectationsWithTimeout(2, handler: nil)
   }
 }
-


### PR DESCRIPTION
### TL;DR

State changes now happen on the next pass of the run loop. To reflect this, we've added a method `queueState(_)` to initiate state changes. We've also made `state` a read-only property. 
### Discussion

Once we removed `redirect` functionality of the transition validator, the natural place for these state changes to live was in the `transitionHandler`. But this could bust the stack (changes to state call the transition handler, which changes state, which calls the transition handler…) 

We now queue state changes on the main thread such that they execute on the next pass of the run loop. This gives the transition handler time to return. Yet, being the main thread, it still provides predictable order of execution while avoiding concurrancy problems.

The major drawback of this approach is that state changes are no longer complete by the time assignment returns:

``` Swift
let machine = StateMachine(initialState: State.Ready)
machine.queueState(State.Fetch)
machine.state //> State.Ready
```

But this was alway a mess, anyway. For example, in the old system, in addition to playing it fast and loose with the stack, you could end up with situations like this:

``` Swift
//LEGACY:
let machine = StateMachine(initialState: State.Ready)
machine.state = State.Fetch 
// Fetch redirects to Fail
doSomethingThatAssumesFetchState()
```

In short? Don't do that. Keep all your state-dependent stuff isolated in your state machine or transition handler. Use it declaratively. Don't rely on ordering or the vagaries what blocks main when. You'll be happier for it.
